### PR TITLE
Emit .eh_frame (unwind info)

### DIFF
--- a/clickhouse-configure
+++ b/clickhouse-configure
@@ -1,0 +1,7 @@
+#!/bin/sh
+CURDIR=$(dirname "$(readlink -f "$0")")
+
+# These are required for unwinding to work:
+#   * -funwind-tables -fasynchronous-unwind-tables  - tell the compiler to generate unwind tables,
+#   * --enable-debug  - tell musl to (1) preprocess assembly files to generate unwind information, (2) add -g (generate debug info, not required for unwinding).
+CFLAGS='-funwind-tables -fasynchronous-unwind-tables' $CURDIR/configure --enable-debug

--- a/configure
+++ b/configure
@@ -496,15 +496,6 @@ tryflag CFLAGS_AUTO -fomit-frame-pointer
 fi
 
 #
-# Modern GCC wants to put DWARF tables (used for debugging and
-# unwinding) in the loaded part of the program where they are
-# unstrippable. These options force them back to debug sections (and
-# cause them not to get generated at all if debugging is off).
-#
-tryflag CFLAGS_AUTO -fno-unwind-tables
-tryflag CFLAGS_AUTO -fno-asynchronous-unwind-tables
-
-#
 # Attempt to put each function and each data object in its own
 # section. This both allows additional size optimizations at link
 # time and works around a dangerous class of compiler/assembler bugs

--- a/tools/add-cfi.i386.awk
+++ b/tools/add-cfi.i386.awk
@@ -8,9 +8,6 @@
 #   and down the call stack and examine the values of local variables
 
 BEGIN {
-  # don't put CFI data in the .eh_frame ELF section (which we don't keep)
-  print ".cfi_sections .debug_frame"
-
   # only emit CFI directives inside a function
   in_function = 0
 

--- a/tools/add-cfi.x86_64.awk
+++ b/tools/add-cfi.x86_64.awk
@@ -1,9 +1,6 @@
 # Insert GAS CFI directives ("control frame information") into x86-64 asm input
 
 BEGIN {
-  # don't put CFI data in the .eh_frame ELF section (which we don't keep)
-  print ".cfi_sections .debug_frame"
-
   # only emit CFI directives inside a function
   in_function = 0
 


### PR DESCRIPTION
Changes needed to make clickouse's stack traces work with musl.

As discussed in https://github.com/ClickHouse/sysroot/pull/26 , IIUC, this goes against the wishes of musl authors - they don't want programs to generate their own stack traces, especially from signal handlers, especially on crash. I couldn't understand exactly why. It's at least in part because of security, but I don't know what exactly is insecure about it. What's the threat model? What types of attacks do they have in mind? Or is it just based on a general principle that program shouldn't have any unnecessary code, especially interpreter-like code? I don't know. Maybe we should look into it.

So this won't be upstreamable.