### PR TITLE
Network fallbacks for environments without /etc/resolv.conf and /etc/hosts

### DIFF
--- a/src/network/lookup_name.c
+++ b/src/network/lookup_name.c
@@ -98,6 +98,29 @@ static int name_from_hosts(struct address buf[static MAXADDRS], char canon[stati
 	return cnt ? cnt : badfam;
 }
 
+static int name_from_localhost(struct address buf[static 2], const char *name, int family)
+{
+	/* RFC 6761: "localhost" and any name under ".localhost" resolve to
+	 * the loopback addresses and must never be sent to DNS resolvers.
+	 * /etc/hosts is processed before this and can still override them.
+	 * This matches the behavior of c-ares and of systemd-resolved and
+	 * keeps "localhost" working when no /etc/hosts exists at all. */
+	static const char tail[] = "localhost";
+	size_t l = strlen(name), i;
+	int cnt = 0;
+	if (l && name[l-1]=='.') l--;
+	if (l != 9 && (l < 11 || name[l-10] != '.'))
+		return 0;
+	for (i=0; i<9; i++)
+		if (tolower(((unsigned char *)name)[l-9+i]) != tail[i])
+			return 0;
+	if (family != AF_INET6)
+		buf[cnt++] = (struct address){ .family = AF_INET, .addr = { 127,0,0,1 } };
+	if (family != AF_INET)
+		buf[cnt++] = (struct address){ .family = AF_INET6, .addr = { [15] = 1 } };
+	return cnt;
+}
+
 struct dpc_ctx {
 	struct address *addrs;
 	char *canon;
@@ -331,6 +354,7 @@ int __lookup_name(struct address buf[static MAXADDRS], char canon[static 256], c
 	if (!cnt) cnt = name_from_numeric(buf, name, family);
 	if (!cnt && !(flags & AI_NUMERICHOST)) {
 		cnt = name_from_hosts(buf, canon, name, family);
+		if (!cnt) cnt = name_from_localhost(buf, name, family);
 		if (!cnt) cnt = name_from_dns_search(buf, canon, name, family);
 	}
 	if (cnt<=0) return cnt ? cnt : EAI_NONAME;

--- a/src/network/resolvconf.c
+++ b/src/network/resolvconf.c
@@ -22,16 +22,18 @@ int __get_resolv_conf(struct resolvconf *conf, char *search, size_t search_sz)
 	if (!f) switch (errno) {
 	case ENOENT:
 	case ENOTDIR:
-	case EACCES:
 		/* When no resolv.conf exists at all (e.g. a container image
 		 * built "from scratch"), fall back to well-known public DNS
 		 * resolvers instead of localhost, which cannot answer in such
 		 * an environment. A resolv.conf that exists but configures no
-		 * nameservers keeps the upstream localhost fallback below,
-		 * since it expresses an intentional local configuration. */
+		 * nameservers (or exists but is unreadable) keeps the upstream
+		 * localhost fallback below, since it expresses an intentional
+		 * local configuration. */
 		if (__lookup_ipliteral(conf->ns+nns, "1.1.1.1", AF_UNSPEC) > 0) nns++;
 		if (__lookup_ipliteral(conf->ns+nns, "8.8.8.8", AF_UNSPEC) > 0) nns++;
 		if (__lookup_ipliteral(conf->ns+nns, "2606:4700:4700::1111", AF_UNSPEC) > 0) nns++;
+		goto no_resolv_conf;
+	case EACCES:
 		goto no_resolv_conf;
 	default:
 		return -1;

--- a/src/network/resolvconf.c
+++ b/src/network/resolvconf.c
@@ -23,6 +23,15 @@ int __get_resolv_conf(struct resolvconf *conf, char *search, size_t search_sz)
 	case ENOENT:
 	case ENOTDIR:
 	case EACCES:
+		/* When no resolv.conf exists at all (e.g. a container image
+		 * built "from scratch"), fall back to well-known public DNS
+		 * resolvers instead of localhost, which cannot answer in such
+		 * an environment. A resolv.conf that exists but configures no
+		 * nameservers keeps the upstream localhost fallback below,
+		 * since it expresses an intentional local configuration. */
+		if (__lookup_ipliteral(conf->ns+nns, "1.1.1.1", AF_UNSPEC) > 0) nns++;
+		if (__lookup_ipliteral(conf->ns+nns, "8.8.8.8", AF_UNSPEC) > 0) nns++;
+		if (__lookup_ipliteral(conf->ns+nns, "2606:4700:4700::1111", AF_UNSPEC) > 0) nns++;
 		goto no_resolv_conf;
 	default:
 		return -1;


### PR DESCRIPTION
Two changes to make a statically linked binary work in a container image built "from scratch", with no files in it at all:

1. **`__get_resolv_conf`**: when `/etc/resolv.conf` does not exist (`ENOENT`/`ENOTDIR`), fall back to well-known public DNS resolvers (`1.1.1.1`, `8.8.8.8`, `2606:4700:4700::1111`) instead of `127.0.0.1`, which cannot answer in such an environment. A `resolv.conf` that exists but configures no nameservers — or exists but is unreadable (`EACCES`) — keeps the upstream localhost fallback, since it expresses an intentional local configuration.

2. **`__lookup_name`**: resolve `localhost` and any name under `.localhost` to the loopback addresses when `/etc/hosts` yields nothing for them, and never send such names to DNS resolvers (RFC 6761). This matches the behavior of c-ares and of systemd-resolved, keeps `localhost` working without `/etc/hosts`, and prevents leaking such queries to the network — which matters more now that the missing-`resolv.conf` fallback points at public resolvers. An `/etc/hosts` entry still takes precedence, since the hosts file is processed first. Note this intentionally applies on fully-configured systems too: a DNS zone that resolves `*.localhost` to non-loopback addresses can now only override via `/etc/hosts`, per RFC 6761.

Verified with a ClickHouse musl build running in a chroot containing only the binary, `/proc`, and `/dev`: DNS resolution works through the fallback resolvers, and `strace` confirms `localhost` lookups produce zero DNS packets while resolving to `127.0.0.1`/`::1`.

Used by: https://github.com/ClickHouse/ClickHouse/pull/115389

🤖 Generated with [Claude Code](https://claude.com/claude-code)